### PR TITLE
Refactor state management by introducing GraphState class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ ipython_config.py
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
 #Pipfile.lock
-
+requirements.txt
 # UV
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more

--- a/examples/example.py
+++ b/examples/example.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
 
     gpt_model = factory.create_model("gpt",openai_api_key = os.getenv('OPENAI_API_KEY'))
 
+    GraphState = GraphState()
     MainState = AgentState([])
     tool_agent = LLMAgent(llm_model= gpt_model, tools = [get_result_sum])
     router_agent = LLMAgent(llm_model= gpt_model)
@@ -61,7 +62,7 @@ if __name__ == "__main__":
 
     edge = Edge(edge_name="edge1", condition=None)
 
-    with Graph(state=MainState) as graph:
+    with Graph(state=GraphState) as graph:
         supervisor_node.connect(to_node=get_sum_node, edge=edge)
         supervisor_node.connect(to_node=get_division_node, edge=edge)
         supervisor_node.connect(to_node=search_internet_node, edge=edge)

--- a/lwagents/__init__.py
+++ b/lwagents/__init__.py
@@ -1,17 +1,20 @@
 from .graph import Graph, Node, Edge, node_router, DirectTraversal
-from .state import AgentState
+from .state import AgentState, GraphState
 from .agent import LLMAgent
 from .tools import Tool
 from .models import LLMFactory
+from .memory import Memory
 
 __all__ = [
     "Graph",
     "Node",
     "Edge",
     "AgentState",
+    "GraphState"
     "LLMAgent",
     "Tool",
     "node_router",
     "DirectTraversal",
     "LLMFactory",
+    "Memory"
 ]

--- a/lwagents/graph.py
+++ b/lwagents/graph.py
@@ -1,4 +1,4 @@
-from .state import AgentState
+from .state import GraphState
 from .agent import LLMAgent
 from dataclasses import dataclass
 from pydantic import BaseModel, Field, SkipValidation
@@ -108,7 +108,7 @@ class Graph(BaseGraph):
 
     def __init__(self, state=None):
         super().__init__()
-        self._AgentState = state or AgentState(None)
+        self._GraphState = state or GraphState(None)
 
     def connect_edge(self, FROM: Node, TO: Node, WITH: Edge):
         """
@@ -213,10 +213,10 @@ class Graph(BaseGraph):
                 **additional_log_entries
             }
 
-            self._AgentState.update_state(**log_entry)
+            self._GraphState.update_state(**log_entry)
 
             if streaming:
-                print("State Global History", self._AgentState.history)
+                print("State Global History", self._GraphState.history)
 
             next_node = None
             if isinstance(result, DirectTraversal):
@@ -264,5 +264,5 @@ class Graph(BaseGraph):
             step_number += 1
 
         if streaming:
-            print(self._AgentState.history)
+            print(self._GraphState.history)
             print("Finished Graph Run")

--- a/lwagents/state.py
+++ b/lwagents/state.py
@@ -43,16 +43,8 @@ class State(ABC):
                     print(f"    {key}: {value}")
             print("-" * 50)
 
-    def update_state(self, step_number, node_name, node_kind, command_result, transition, **kwargs) -> None:
-        log_entry = {
-            "step_number": step_number,
-            "node_name": node_name,
-            "node_kind": node_kind,
-            "command_result": command_result,
-            "transition": transition,
-            **kwargs}
-        self.history.append(log_entry)
-        self.last_update = log_entry
+    def update_state(self) -> None:
+        pass
 
 # Concrete Implementation
 class AgentState(State):
@@ -81,12 +73,32 @@ class AgentState(State):
             )
 
     @override
+    def update_state(self, **kwargs) -> None:
+        """
+        Updates the agent state with a new log entry.
+        """
+        state_entry = {
+            **kwargs
+        }
+
+
+class GraphState(State):
+
+    def __init__(self, initial_history: Optional[List] = []):
+        super().__init__(initial_history=initial_history)
+
+    @override
     def update_state(self, step_number, node_name, node_kind, command_result, transition, **kwargs) -> None:
         """
         Updates the agent state with a new log entry.
         """
-        super().update_state(step_number, node_name, node_kind, command_result, transition, **kwargs)
-
-
-        
+        log_entry = {
+            "step_number": step_number,
+            "node_name": node_name,
+            "node_kind": node_kind,
+            "command_result": command_result,
+            "transition": transition,
+            **kwargs}
+        self.history.append(log_entry)
+        self.last_update = log_entry
 


### PR DESCRIPTION
- Added GraphState class to manage graph-related state.
- Updated example.py to instantiate GraphState and use it in the Graph context.
- Modified __init__.py to include GraphState in the module exports.
- Adjusted graph.py to utilize GraphState instead of AgentState for state management.
- Updated state.py to implement GraphState with a custom update_state method.
- Added requirements.txt to .gitignore.