### PR TITLE
Refactor example.py and graph.py to integrate GraphRequest functionality

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -23,7 +23,6 @@ def get_division():
 def search_internet():
     return "RESULTS HAVE BEEN VERIFIED"
 
-@node_router
 def test_router(agent):
     global_state = get_global_agent_state()
     prompt =[{"role": "system", "content": "You are an agent router and you decide which node to travel to next based on the task and results thus far. Your next answer must only return the node name."},
@@ -33,7 +32,7 @@ def test_router(agent):
     # You can also access global state here to see all agent activities
     #print(f"Router agent executed. Total agent actions: {len(global_state.history)}")
     
-    return result.content
+    return GraphRequest(result=result.content, traversal=result.content)
 
 if __name__ == "__main__":
     load_dotenv()

--- a/lwagents/__init__.py
+++ b/lwagents/__init__.py
@@ -6,14 +6,11 @@ from . import tools
 from . import models
 
 # Export commonly used classes directly at package level
-from .graph import Graph, Node, Edge
+from .graph import Graph, Node, Edge, GraphRequest
 from .state import AgentState, GraphState, get_global_agent_state, reset_global_agent_state
 from .agent import LLMAgent
 from .tools import Tool
 from .models import LLMFactory
-
-# Keep decorators and special functions at top level
-from .graph import node_router, DirectTraversal
 
 __all__ = [
     # Modules (for advanced users who want lwagents.state.something)
@@ -34,8 +31,7 @@ __all__ = [
     "LLMFactory",
     
     # Functions and utilities
-    "node_router",
-    "DirectTraversal",
+    "GraphRequest",
     "get_global_agent_state", 
     "reset_global_agent_state",
 ]


### PR DESCRIPTION
- Removed the node_router decorator from example.py and updated the test_router function to return a GraphRequest object.
- Updated __init__.py to include GraphRequest in the module exports.
- Refactored graph.py to implement GraphRequest and DirectTraversalRequest classes, enhancing command execution and state management.
- Adjusted the Graph class to handle GraphRequest objects and their associated parameters and commands.